### PR TITLE
Alter order of tabs.

### DIFF
--- a/maildump/templates/index.html
+++ b/maildump/templates/index.html
@@ -57,11 +57,11 @@
             <dl class="meta" id="message-metadata"></dl>
             <nav class="views">
                 <ul>
-                    <li class="tab selected format plain" data-message-format="plain">
-                        <a href="#">Plain Text</a>
-                    </li>
                     <li class="tab format html" data-message-format="html">
                         <a href="#">HTML</a>
+                    </li>
+                    <li class="tab selected format plain" data-message-format="plain">
+                        <a href="#">Plain Text</a>
                     </li>
                     <li class="tab format source" data-message-format="source">
                         <a href="#">Source</a>


### PR DESCRIPTION
The screenshot of MailCatcher at https://github.com/sj26/mailcatcher
shows the tabs in the order: html, plain, source. The template is
updated to mimic that behaviour.

I noticed this when I had been using maildump for a while and constantly had to shift from plain- to html-tab. So I made some research and initially changed message.js to automatically select ":visible.html" instead of ":visible:first". But I think this proposed change is somewhat more correct behaviour.

You could even add an extra option where you could select the order during startup, but that would add extra complexity that might not be needed...