### PR TITLE
Avoid choking on malformed multipart e-mails

### DIFF
--- a/maildump/db.py
+++ b/maildump/db.py
@@ -99,6 +99,7 @@ def _add_message_part(message_id, cid, part):
     """
 
     body = part.get_payload(decode=True)
+    body_len = len(body) if body else 0
     _conn.execute(sql, (message_id,
                         cid,
                         part.get_content_type(),
@@ -106,7 +107,7 @@ def _add_message_part(message_id, cid, part):
                         part.get_filename(),
                         part.get_content_charset(),
                         body,
-                        len(body)))
+                        body_len))
 
 
 def _get_message_cols(lightweight):


### PR DESCRIPTION
I'm using maildump with a Java app (using Spring and JavaMail for sending mail) that sends multipart mails which the smtpd module fails to parse correctly for some reason.

The pr adds a guard for when smtpd returns None from part.get_payload. Without this, an exception is thrown and the client gives up sending the mail after receiving status -1 rather than 250.

Here is an example mail:

````
Date: Mon, 2 Mar 2015 18:09:13 +0100 (CET)
From: Mail From <from@example.com>
To: Mail To <to@example.com>
Message-ID: <112619572.3.1425316153190.JavaMail.hansjorg@eris>
Subject: Email subject
MIME-Version: 1.0
Content-Type: multipart/mixed; 
	boundary="----=_Part_0_1004095028.1425316153168"

------=_Part_0_1004095028.1425316153168
Content-Type: multipart/related; 
	boundary="----=_Part_1_1485697819.1425316153171"

------=_Part_1_1485697819.1425316153171
Content-Type: multipart/alternative; 
	boundary="----=_Part_2_867398280.1425316153171"

------=_Part_2_867398280.1425316153171
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 7bit

Plain text email.
------=_Part_2_867398280.1425316153171
Content-Type: text/html;charset=UTF-8
Content-Transfer-Encoding: 7bit

<b>HTML</b> email.
------=_Part_2_867398280.1425316153171--

------=_Part_1_1485697819.1425316153171--

------=_Part_0_1004095028.1425316153168--
````

