### PR TITLE
Showing HTML of emails by default

### DIFF
--- a/maildump/templates/index.html
+++ b/maildump/templates/index.html
@@ -57,11 +57,11 @@
             <dl class="meta" id="message-metadata"></dl>
             <nav class="views">
                 <ul>
-                    <li class="tab selected format plain" data-message-format="plain">
-                        <a href="#">Plain Text</a>
-                    </li>
                     <li class="tab format html" data-message-format="html">
                         <a href="#">HTML</a>
+                    </li>
+                    <li class="tab selected format plain" data-message-format="plain">
+                        <a href="#">Plain Text</a>
                     </li>
                     <li class="tab format source" data-message-format="source">
                         <a href="#">Source</a>


### PR DESCRIPTION
Showing HTML by default is closer to actual behaviours of email clients, probably show HTML version by default if there's one present.