### PR TITLE
SMTP Auth

### DIFF
--- a/maildump/__init__.py
+++ b/maildump/__init__.py
@@ -12,7 +12,7 @@ log = Logger(__name__)
 stopper = None
 
 
-def start(http_host, http_port, smtp_host, smtp_port, smtp_auth, smtp_username, smtp_password, db_path=None):
+def start(http_host, http_port, smtp_host, smtp_port, smtp_auth, db_path=None):
     global stopper
     # Webserver
     log.notice('Starting web server on http://{0}:{1}'.format(http_host, http_port))
@@ -21,8 +21,8 @@ def start(http_host, http_port, smtp_host, smtp_port, smtp_auth, smtp_username, 
     # SMTP server
     log.notice('Starting smtp server on {0}:{1}'.format(smtp_host, smtp_port))
     if smtp_auth:
-        log.notice('Enabled SMTP authorization for user {0}'.format(smtp_username))
-    SMTPServer((smtp_host, smtp_port), smtp_handler, smtp_auth, smtp_username, smtp_password)
+        log.notice('Enabled SMTP authorization with htpasswd file {0}'.format(smtp_auth))
+    SMTPServer((smtp_host, smtp_port), smtp_handler, smtp_auth)
     gevent.spawn(asyncore.loop)
     # Database
     connect(db_path)

--- a/maildump/__init__.py
+++ b/maildump/__init__.py
@@ -12,7 +12,7 @@ log = Logger(__name__)
 stopper = None
 
 
-def start(http_host, http_port, smtp_host, smtp_port, db_path=None):
+def start(http_host, http_port, smtp_host, smtp_port, smtp_auth, smtp_username, smtp_password, db_path=None):
     global stopper
     # Webserver
     log.notice('Starting web server on http://{0}:{1}'.format(http_host, http_port))
@@ -20,7 +20,9 @@ def start(http_host, http_port, smtp_host, smtp_port, db_path=None):
     stopper = http_server.close
     # SMTP server
     log.notice('Starting smtp server on {0}:{1}'.format(smtp_host, smtp_port))
-    SMTPServer((smtp_host, smtp_port), smtp_handler)
+    if smtp_auth:
+        log.notice('Enabled SMTP authorization for user {0}'.format(smtp_username))
+    SMTPServer((smtp_host, smtp_port), smtp_handler, smtp_auth, smtp_username, smtp_password)
     gevent.spawn(asyncore.loop)
     # Database
     connect(db_path)

--- a/maildump/smtp.py
+++ b/maildump/smtp.py
@@ -30,7 +30,7 @@ class SMTPChannel(smtpd.SMTPChannel, object):
         self.push('250 HELP')
 
     def smtp_AUTH(self, arg):
-        print >> DEBUGSTREAM, '===> AUTH', arg
+        print >> smtpd.DEBUGSTREAM, '===> AUTH', arg
         if not self._smtp_auth:
             self.push('501 Syntax: AUTH not enabled')
             return

--- a/maildump/smtp.py
+++ b/maildump/smtp.py
@@ -3,6 +3,7 @@ import smtpd
 from email.parser import BytesParser
 
 from logbook import Logger
+from passlib.apache import HtpasswdFile
 
 from maildump.db import add_message
 
@@ -10,11 +11,9 @@ log = Logger(__name__)
 
 
 class SMTPChannel(smtpd.SMTPChannel, object):
-    def __init__(self, server, conn, addr, smtp_auth, smtp_username, smtp_password):
+    def __init__(self, server, conn, addr, smtp_auth):
         super(SMTPChannel, self).__init__(server, conn, addr)
         self._smtp_auth = smtp_auth
-        self._smtp_username = smtp_username
-        self._smtp_password = smtp_password
         self._authorized = False
 
     def smtp_EHLO(self, arg):
@@ -53,7 +52,7 @@ class SMTPChannel(smtpd.SMTPChannel, object):
 
         auth_data = auth_data.split('\x00')
         if (len(auth_data) == 3 and auth_data[0] == auth_data[1] and
-                auth_data[1] == self._smtp_username and auth_data[2] == self._smtp_password):
+                self._smtp_auth.check_password(auth_data[1], auth_data[2])):
             self.push('235 Authentication successful')
             self._authorized = True
             return
@@ -81,19 +80,17 @@ class SMTPChannel(smtpd.SMTPChannel, object):
 
 
 class SMTPServer(smtpd.SMTPServer, object):
-    def __init__(self, listener, handler, smtp_auth, smtp_username, smtp_password):
+    def __init__(self, listener, handler, smtp_auth):
         super(SMTPServer, self).__init__(listener, None)
         self._handler = handler
         self._smtp_auth = smtp_auth
-        self._smtp_username = smtp_username
-        self._smtp_password = smtp_password
 
     def handle_accept(self):
         pair = self.accept()
         if pair is not None:
             conn, addr = pair
             print >> smtpd.DEBUGSTREAM, 'Incoming connection from %s' % repr(addr)
-            channel = SMTPChannel(self, conn, addr, self._smtp_auth, self._smtp_username, self._smtp_password)
+            channel = SMTPChannel(self, conn, addr, self._smtp_auth)
 
     def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         return self._handler(sender=mailfrom, recipients=rcpttos, body=data)

--- a/maildump/smtp.py
+++ b/maildump/smtp.py
@@ -16,6 +16,16 @@ class SMTPChannel(smtpd.SMTPChannel, object):
         self._smtp_auth = smtp_auth
         self._authorized = False
 
+    def is_valid_user(self, auth_data):
+        auth_data_splitted = auth_data.split('\x00')
+        if len(auth_data_splitted) != 3:
+            return False
+
+        if not auth_data.startswith('\x00') and auth_data_splitted[0] != auth_data_splitted[1]:
+            return False
+
+        return self._smtp_auth.check_password(auth_data_splitted[1], auth_data_splitted[2])
+
     def smtp_EHLO(self, arg):
         if not arg:
             self.push('501 Syntax: EHLO hostname')
@@ -50,9 +60,7 @@ class SMTPChannel(smtpd.SMTPChannel, object):
             self.push('535 5.7.8 Authentication credentials invalid')
             return
 
-        auth_data = auth_data.split('\x00')
-        if (len(auth_data) == 3 and auth_data[0] == auth_data[1] and
-                self._smtp_auth.check_password(auth_data[1], auth_data[2])):
+        if self.is_valid_user(auth_data):
             self.push('235 Authentication successful')
             self._authorized = True
             return

--- a/maildump/smtp.py
+++ b/maildump/smtp.py
@@ -20,22 +20,11 @@ class SMTPChannel(smtpd.SMTPChannel, object):
         if not arg:
             self.push('501 Syntax: EHLO hostname')
             return
-        # See issue #21783 for a discussion of this behavior.
-        if self.seen_greeting:
+        if self.__greeting:
             self.push('503 Duplicate HELO/EHLO')
             return
-        self._set_rset_state()
-        self.seen_greeting = arg
-        self.extended_smtp = True
-        self.push('250-%s' % self.fqdn)
-        if self.data_size_limit:
-            self.push('250-SIZE %s' % self.data_size_limit)
-            self.command_size_limits['MAIL'] += 26
-        if not self._decode_data:
-            self.push('250-8BITMIME')
-        if self.enable_SMTPUTF8:
-            self.push('250-SMTPUTF8')
-            self.command_size_limits['MAIL'] += 10
+        self.__greeting = arg
+        self.push('250-%s' % self.__fqdn)
         if self._smtp_auth:
             self.push('250-AUTH PLAIN')
         self.push('250 HELP')

--- a/maildump/smtp.py
+++ b/maildump/smtp.py
@@ -15,6 +15,7 @@ class SMTPChannel(smtpd.SMTPChannel, object):
         self._smtp_auth = smtp_auth
         self._smtp_username = smtp_username
         self._smtp_password = smtp_password
+        self._authorized = False
 
     def smtp_EHLO(self, arg):
         if not arg:
@@ -54,9 +55,29 @@ class SMTPChannel(smtpd.SMTPChannel, object):
         if len(auth_data) == 3 and auth_data[0] == auth_data[1] and \
                 auth_data[1] == self._smtp_username and auth_data[2] == self._smtp_password:
             self.push('235 Authentication successful')
+            self._authorized = True
             return
 
+        self._authorized = False
         self.push('535 5.7.8 Authentication credentials invalid')
+
+    def smtp_MAIL(self, arg):
+        if self._smtp_auth and not self._authorized:
+            self.push('530 5.7.0  Authentication required')
+            return
+        super(SMTPChannel, self).smtp_MAIL(arg)
+
+    def smtp_RCPT(self, arg):
+        if self._smtp_auth and not self._authorized:
+            self.push('530 5.7.0  Authentication required')
+            return
+        super(SMTPChannel, self).smtp_RCPT(arg)
+
+    def smtp_DATA(self, arg):
+        if self._smtp_auth and not self._authorized:
+            self.push('530 5.7.0  Authentication required')
+            return
+        super(SMTPChannel, self).smtp_DATA(arg)
 
 
 class SMTPServer(smtpd.SMTPServer, object):

--- a/maildump/smtp.py
+++ b/maildump/smtp.py
@@ -52,8 +52,8 @@ class SMTPChannel(smtpd.SMTPChannel, object):
             return
 
         auth_data = auth_data.split('\x00')
-        if len(auth_data) == 3 and auth_data[0] == auth_data[1] and \
-                auth_data[1] == self._smtp_username and auth_data[2] == self._smtp_password:
+        if (len(auth_data) == 3 and auth_data[0] == auth_data[1] and
+                auth_data[1] == self._smtp_username and auth_data[2] == self._smtp_password):
             self.push('235 Authentication successful')
             self._authorized = True
             return

--- a/maildump/smtp.py
+++ b/maildump/smtp.py
@@ -1,3 +1,4 @@
+import base64
 import smtpd
 from email.parser import BytesParser
 
@@ -8,10 +9,81 @@ from maildump.db import add_message
 log = Logger(__name__)
 
 
+class SMTPChannel(smtpd.SMTPChannel, object):
+    def __init__(self, server, conn, addr, smtp_auth, smtp_username, smtp_password):
+        super(SMTPChannel, self).__init__(server, conn, addr)
+        self._smtp_auth = smtp_auth
+        self._smtp_username = smtp_username
+        self._smtp_password = smtp_password
+
+    def smtp_EHLO(self, arg):
+        if not arg:
+            self.push('501 Syntax: EHLO hostname')
+            return
+        # See issue #21783 for a discussion of this behavior.
+        if self.seen_greeting:
+            self.push('503 Duplicate HELO/EHLO')
+            return
+        self._set_rset_state()
+        self.seen_greeting = arg
+        self.extended_smtp = True
+        self.push('250-%s' % self.fqdn)
+        if self.data_size_limit:
+            self.push('250-SIZE %s' % self.data_size_limit)
+            self.command_size_limits['MAIL'] += 26
+        if not self._decode_data:
+            self.push('250-8BITMIME')
+        if self.enable_SMTPUTF8:
+            self.push('250-SMTPUTF8')
+            self.command_size_limits['MAIL'] += 10
+        if self._smtp_auth:
+            self.push('250-AUTH PLAIN')
+        self.push('250 HELP')
+
+    def smtp_AUTH(self, arg):
+        print >> DEBUGSTREAM, '===> AUTH', arg
+        if not self._smtp_auth:
+            self.push('501 Syntax: AUTH not enabled')
+            return
+
+        if not arg:
+            self.push('501 Syntax: AUTH TYPE base64(username:password)')
+            return
+
+        if not arg.lower().startswith('plain '):
+            self.push('501 Syntax: only PLAIN auth possible')
+            return
+
+        auth_type, auth_data = arg.split(None, 1)
+        try:
+            auth_data = base64.b64decode(auth_data.strip())
+        except TypeError:
+            self.push('535 5.7.8 Authentication credentials invalid')
+            return
+
+        auth_data = auth_data.split('\x00')
+        if len(auth_data) == 3 and auth_data[0] == auth_data[1] and \
+                auth_data[1] == self._smtp_username and auth_data[2] == self._smtp_password:
+            self.push('235 Authentication successful')
+            return
+
+        self.push('535 5.7.8 Authentication credentials invalid')
+
+
 class SMTPServer(smtpd.SMTPServer, object):
-    def __init__(self, listener, handler):
+    def __init__(self, listener, handler, smtp_auth, smtp_username, smtp_password):
         super(SMTPServer, self).__init__(listener, None)
         self._handler = handler
+        self._smtp_auth = smtp_auth
+        self._smtp_username = smtp_username
+        self._smtp_password = smtp_password
+
+    def handle_accept(self):
+        pair = self.accept()
+        if pair is not None:
+            conn, addr = pair
+            print >> smtpd.DEBUGSTREAM, 'Incoming connection from %s' % repr(addr)
+            channel = SMTPChannel(self, conn, addr, self._smtp_auth, self._smtp_username, self._smtp_password)
 
     def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         return self._handler(sender=mailfrom, recipients=rcpttos, body=data)

--- a/maildump_runner/main.py
+++ b/maildump_runner/main.py
@@ -35,9 +35,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--smtp-ip', default='127.0.0.1', metavar='IP', help='SMTP ip (default: 127.0.0.1)')
     parser.add_argument('--smtp-port', default=1025, type=int, metavar='PORT', help='SMTP port (default: 1025)')
-    parser.add_argument('--smtp-auth', action='store_true', help='Enable SMTP authorization')
-    parser.add_argument('--smtp-username', default='maildump', help='SMTP username (default: maildump)')
-    parser.add_argument('--smtp-password', default='maildump', help='SMTP password (deault: maildump)')
+    parser.add_argument('--smtp-auth', metavar='HTPASSWD', help='Apache-style htpasswd file for SMTP authorization')
     parser.add_argument('--http-ip', default='127.0.0.1', metavar='IP', help='HTTP ip (default: 127.0.0.1)')
     parser.add_argument('--http-port', default=1080, type=int, metavar='PORT', help='HTTP port (default: 1080)')
     parser.add_argument('--db', metavar='PATH', help='SQLite database - in-memory if missing')
@@ -146,13 +144,14 @@ def main():
                 raise
             app.config['MAILDUMP_HTPASSWD'] = HtpasswdFile(args.htpasswd)
         app.config['MAILDUMP_NO_QUIT'] = args.no_quit
+        smtp_auth = HtpasswdFile(args.smtp_auth) if args.smtp_auth else None
 
         level = logbook.DEBUG if args.debug else logbook.INFO
         format_string = u'[{record.time:%Y-%m-%d %H:%M:%S}]  {record.level_name:<8}  {record.channel}: {record.message}'
         stderr_handler = ColorizedStderrHandler(level=level, format_string=format_string)
         with NullHandler().applicationbound():
             with stderr_handler.applicationbound():
-                start(args.http_ip, args.http_port, args.smtp_ip, args.smtp_port, args.smtp_auth, args.smtp_username, args.smtp_password, args.db)
+                start(args.http_ip, args.http_port, args.smtp_ip, args.smtp_port, smtp_auth, args.db)
 
 
 if __name__ == '__main__':

--- a/maildump_runner/main.py
+++ b/maildump_runner/main.py
@@ -35,7 +35,10 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--smtp-ip', default='127.0.0.1', metavar='IP', help='SMTP ip (default: 127.0.0.1)')
     parser.add_argument('--smtp-port', default=1025, type=int, metavar='PORT', help='SMTP port (default: 1025)')
-    parser.add_argument('--smtp-auth', metavar='HTPASSWD', help='Apache-style htpasswd file for SMTP authorization')
+    parser.add_argument('--smtp-auth', metavar='HTPASSWD', help='Apache-style htpasswd file for SMTP authorization. '
+                                                                'WARNING: do not rely only on this as a security '
+                                                                'mechanism, use also additional methods for securing '
+                                                                'MailDump instance, ie. IP restrictions.')
     parser.add_argument('--http-ip', default='127.0.0.1', metavar='IP', help='HTTP ip (default: 127.0.0.1)')
     parser.add_argument('--http-port', default=1080, type=int, metavar='PORT', help='HTTP port (default: 1080)')
     parser.add_argument('--db', metavar='PATH', help='SQLite database - in-memory if missing')

--- a/maildump_runner/main.py
+++ b/maildump_runner/main.py
@@ -38,7 +38,7 @@ def main():
     parser.add_argument('--smtp-auth', metavar='HTPASSWD', help='Apache-style htpasswd file for SMTP authorization. '
                                                                 'WARNING: do not rely only on this as a security '
                                                                 'mechanism, use also additional methods for securing '
-                                                                'MailDump instance, ie. IP restrictions.')
+                                                                'your MailDump instance, ie. IP restrictions.')
     parser.add_argument('--http-ip', default='127.0.0.1', metavar='IP', help='HTTP ip (default: 127.0.0.1)')
     parser.add_argument('--http-port', default=1080, type=int, metavar='PORT', help='HTTP port (default: 1080)')
     parser.add_argument('--db', metavar='PATH', help='SQLite database - in-memory if missing')

--- a/maildump_runner/main.py
+++ b/maildump_runner/main.py
@@ -91,9 +91,17 @@ def main():
         args.htpasswd = os.path.abspath(args.htpasswd)
         print('Htpasswd path is relative, using {0}'.format(args.htpasswd))
 
+    if args.smtp_auth and not os.path.isabs(args.smtp_auth):
+        args.smtp_auth = os.path.abspath(args.smtp_auth)
+        print('SMTP Htpasswd path is relative, using {0}'.format(args.smtp_auth))
+
     # Check if the password file is valid
     if args.htpasswd and not os.path.isfile(args.htpasswd):
         print('Htpasswd file does not exist')
+        sys.exit(1)
+
+    if args.smtp_auth and not os.path.isfile(args.smtp_auth):
+        print('SMTP Htpasswd file does not exist')
         sys.exit(1)
 
     daemon_kw = {
@@ -137,7 +145,7 @@ def main():
 
         app.debug = args.debug
         app.config['MAILDUMP_HTPASSWD'] = None
-        if args.htpasswd:
+        if args.htpasswd or args.smtp_auth:
             # passlib is broken on py39, hence the local import
             # https://foss.heptapod.net/python-libs/passlib/-/issues/115
             try:
@@ -145,6 +153,8 @@ def main():
             except OSError:
                 print('Are you using Python 3.9? If yes, authentication is currently not available due to a bug.\n\n')
                 raise
+
+        if args.htpasswd:
             app.config['MAILDUMP_HTPASSWD'] = HtpasswdFile(args.htpasswd)
         app.config['MAILDUMP_NO_QUIT'] = args.no_quit
         smtp_auth = HtpasswdFile(args.smtp_auth) if args.smtp_auth else None

--- a/maildump_runner/main.py
+++ b/maildump_runner/main.py
@@ -93,7 +93,7 @@ def main():
 
     if args.smtp_auth and not os.path.isabs(args.smtp_auth):
         args.smtp_auth = os.path.abspath(args.smtp_auth)
-        print('SMTP Htpasswd path is relative, using {0}'.format(args.smtp_auth))
+        print('Htpasswd path for SMTP AUTH is relative, using {0}'.format(args.smtp_auth))
 
     # Check if the password file is valid
     if args.htpasswd and not os.path.isfile(args.htpasswd):
@@ -101,7 +101,7 @@ def main():
         sys.exit(1)
 
     if args.smtp_auth and not os.path.isfile(args.smtp_auth):
-        print('SMTP Htpasswd file does not exist')
+        print('Htpasswd file for SMTP AUTH does not exist')
         sys.exit(1)
 
     daemon_kw = {

--- a/maildump_runner/main.py
+++ b/maildump_runner/main.py
@@ -35,6 +35,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--smtp-ip', default='127.0.0.1', metavar='IP', help='SMTP ip (default: 127.0.0.1)')
     parser.add_argument('--smtp-port', default=1025, type=int, metavar='PORT', help='SMTP port (default: 1025)')
+    parser.add_argument('--smtp-auth', action='store_true', help='Enable SMTP authorization')
+    parser.add_argument('--smtp-username', default='maildump', help='SMTP username (default: maildump)')
+    parser.add_argument('--smtp-password', default='maildump', help='SMTP password (deault: maildump)')
     parser.add_argument('--http-ip', default='127.0.0.1', metavar='IP', help='HTTP ip (default: 127.0.0.1)')
     parser.add_argument('--http-port', default=1080, type=int, metavar='PORT', help='HTTP port (default: 1080)')
     parser.add_argument('--db', metavar='PATH', help='SQLite database - in-memory if missing')
@@ -149,7 +152,7 @@ def main():
         stderr_handler = ColorizedStderrHandler(level=level, format_string=format_string)
         with NullHandler().applicationbound():
             with stderr_handler.applicationbound():
-                start(args.http_ip, args.http_port, args.smtp_ip, args.smtp_port, args.db)
+                start(args.http_ip, args.http_port, args.smtp_ip, args.smtp_port, args.smtp_auth, args.smtp_username, args.smtp_password, args.db)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
added option to handle smtp authorization. There exists stuff that requires SMTP authorization, and cannot use no auth at all. So I added an option to enable this using options:
--smtp-auth - enable SMTP authorization
--smtp-username, --smtp-password